### PR TITLE
Adding example on how to enable image-automation-controller through Bicep

### DIFF
--- a/bicep/flux-aks-example.bicep
+++ b/bicep/flux-aks-example.bicep
@@ -26,6 +26,10 @@ resource fluxExtensions 'Microsoft.KubernetesConfiguration/extensions@2022-03-01
   properties: {
     extensionType: 'microsoft.flux'
   }
+  configurationSettings: {
+    'image-automation-controller.enabled': 'true' 
+    'image-reflector-controller.enabled': 'true'
+  }
   scope: managedClusters[i]
 }]
 

--- a/bicep/flux-aks-https-key-example.bicep
+++ b/bicep/flux-aks-https-key-example.bicep
@@ -26,6 +26,10 @@ resource fluxExtensions 'Microsoft.KubernetesConfiguration/extensions@2022-03-01
   properties: {
     extensionType: 'microsoft.flux'
   }
+  configurationSettings: {
+    'image-automation-controller.enabled': 'true' 
+    'image-reflector-controller.enabled': 'true'
+  }
   scope: managedClusters[i]
 }]
 

--- a/bicep/flux-aks-private-key-example.bicep
+++ b/bicep/flux-aks-private-key-example.bicep
@@ -26,6 +26,10 @@ resource fluxExtensions 'Microsoft.KubernetesConfiguration/extensions@2022-03-01
   properties: {
     extensionType: 'microsoft.flux'
   }
+  configurationSettings: {
+    'image-automation-controller.enabled': 'true' 
+    'image-reflector-controller.enabled': 'true'
+  }
   scope: managedClusters[i]
 }]
 


### PR DESCRIPTION
As mentioned https://github.com/Azure/gitops-flux2-kustomize-helm-mt/issues/5 and https://docs.microsoft.com/en-us/answers/questions/930910/aks-flux-extension-imageupdateautomation-support.html it's a bit complicated to understand from documentation on how to enable https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/tutorial-use-gitops-flux2#control-which-controllers-are-deployed-with-the-flux-cluster-extension in Bicep.

This PR will not add additional value for the Proof of Concept but would help to understand on how to configure Azure Flux for production usage