### PR TITLE
Fix reconciliation error caused by chart version

### DIFF
--- a/infrastructure/nginx/release.yaml
+++ b/infrastructure/nginx/release.yaml
@@ -13,7 +13,7 @@ spec:
         kind: HelmRepository
         name: bitnami
         namespace: cluster-config
-      version: "9.1.11"
+      version: "9.3.25"
   interval: 1h0m0s
   install:
     remediation:


### PR DESCRIPTION
When deploying with chart version 9.1.11, was receiving a reconciliation error for the nginx-ingress-controller chart.  Bumping to 9.3.25 seems to have fixed it.